### PR TITLE
Fix attach assert

### DIFF
--- a/src/class/prte_hash_table.c
+++ b/src/class/prte_hash_table.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -86,6 +87,8 @@
  * implementation just needs to be a little careful.
  *
  */
+
+#define HASH_SHOW_REPLACEMENT_WARNING 0
 
 #define HASH_MULTIPLIER 31
 
@@ -405,6 +408,11 @@ prte_hash_table_set_value_uint32(prte_hash_table_t * ht, uint32_t key, void * va
             }
             return PRTE_SUCCESS;
         } else if (elt->key.u32 == key) {
+#if PRTE_ENABLE_DEBUG && HASH_SHOW_REPLACEMENT_WARNING == 1
+            prte_output(0, "prte_hash_table_set_value_uint32: "
+                        "Warning: replacing existing value for key %u",
+                        key);
+#endif
             /* replace existing element */
             elt->value = value;
             return PRTE_SUCCESS;
@@ -539,6 +547,12 @@ prte_hash_table_set_value_uint64(prte_hash_table_t * ht, uint64_t key, void * va
             }
             return PRTE_SUCCESS;
         } else if (elt->key.u64 == key) {
+#if PRTE_ENABLE_DEBUG && HASH_SHOW_REPLACEMENT_WARNING == 1
+            prte_output(0, "prte_hash_table_set_value_uint64: "
+                        "Warning: replacing existing value for key %lu",
+                        key);
+#endif
+            /* replace existing element */
             elt->value = value;
             return PRTE_SUCCESS;
         } else {
@@ -708,6 +722,11 @@ prte_hash_table_set_value_ptr(prte_hash_table_t * ht,
             return PRTE_SUCCESS;
         } else if (elt->key.ptr.key_size == key_size &&
                    0 == memcmp(elt->key.ptr.key, key, key_size)) {
+#if PRTE_ENABLE_DEBUG && HASH_SHOW_REPLACEMENT_WARNING == 1
+            prte_output(0, "prte_hash_table_set_value_ptr: "
+                        "Warning: replacing existing value for key %p",
+                        key);
+#endif
             /* replace existing value */
             elt->value = value;
             return PRTE_SUCCESS;

--- a/src/class/prte_hash_table.c
+++ b/src/class/prte_hash_table.c
@@ -88,6 +88,13 @@
  *
  */
 
+/*
+ * This hash table implementation does not chain duplicate entries, but
+ * instead replaces what was there before. Set this variable to "1" to
+ * show a warning message when this happens.
+ * Such a warning is helpful in detecting when objects might be
+ * orphaned as a result of this replacement.
+ */
 #define HASH_SHOW_REPLACEMENT_WARNING 0
 
 #define HASH_MULTIPLIER 31

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
- * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -454,7 +454,7 @@ int prte_odls_base_default_construct_child_list(prte_buffer_t *buffer,
             /* check to see if we already have this one */
             if (NULL == prte_get_job_data_object(jdata->jobid)) {
                 /* nope - add it */
-                prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+                prte_set_job_data_object(jdata->jobid, jdata);
             } else {
                 /* yep - so we can drop this copy */
                 jdata->jobid = PRTE_JOBID_INVALID;
@@ -534,7 +534,7 @@ int prte_odls_base_default_construct_child_list(prte_buffer_t *buffer,
             goto REPORT_ERROR;
         }
     } else {
-        prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+        prte_set_job_data_object(jdata->jobid, jdata);
 
         /* ensure the map object is present */
         if (NULL == jdata->map) {

--- a/src/mca/plm/base/plm_base_jobid.c
+++ b/src/mca/plm/base/plm_base_jobid.c
@@ -102,6 +102,7 @@ int prte_plm_base_create_jobid(prte_job_t *jdata)
     bool found;
     char *tmp;
     int rc;
+    prte_job_t *old_jdata;
 
     if (PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_RESTART)) {
         /* this job is being restarted - do not assign it
@@ -139,12 +140,23 @@ int prte_plm_base_create_jobid(prte_job_t *jdata)
     prte_asprintf(&tmp, "%s.%u", prte_process_info.myproc.nspace, (unsigned)prte_plm_globals.next_jobid);
     PMIX_LOAD_NSPACE(jdata->nspace, tmp);
     free(tmp);
-    // This routine will create a new prte_job_t structure and add it to the
-    // prte_job_data hash table at the ".N" position.
+    // The following routine will create a new prte_job_t structure and add it
+    // to the prte_job_data hash table at the ".N" position. Note that the 'new'
+    // object is not the 'jdata' referenced here. After this call we have
+    // two objects in the system with the same jobid/nspace.
     PRTE_PMIX_CONVERT_NSPACE(rc, &jdata->jobid, jdata->nspace);
     if (PRTE_SUCCESS != rc) {
         return rc;
     }
+    // Replace the 'new' (temporary) object with the one passed to this function
+    old_jdata = prte_set_job_data_object(jdata->jobid, jdata);
+    // Release the temporary object, but mark the jobid as invalid so the
+    // destructor does not remove the object we just put on the hash.
+    old_jdata->jobid = PRTE_JOBID_INVALID;
+    if (NULL != old_jdata) {
+        PRTE_RELEASE(old_jdata);
+    }
+
     prte_plm_globals.next_jobid++;
     if (INT16_MAX == prte_plm_globals.next_jobid) {
         reuse = true;

--- a/src/mca/plm/base/plm_base_jobid.c
+++ b/src/mca/plm/base/plm_base_jobid.c
@@ -61,7 +61,12 @@ int prte_plm_base_set_hnp_name(void)
         return PRTE_SUCCESS;
     }
 
-    /* for our nspace, we will use the nodename+pid */
+    /* for our nspace, we will use the nodename+pid
+     * Note that we do not add the .0 suffix to the namespace as we do with
+     * the children namespaces. The daemon jobfamily is always "0".
+     * The PRTE_PMIX_CONVERT_NSPACE routine will create the prte_job_t structre
+     * and add it to the prte_job_data hash table at position "0".
+     */
     prte_asprintf(&evar, "%s-%s%u", prte_tool_basename, prte_process_info.nodename, (uint32_t)prte_process_info.pid);
 
     PRTE_PMIX_CONVERT_NSPACE(rc, &PRTE_PROC_MY_NAME->jobid, evar);
@@ -78,7 +83,6 @@ int prte_plm_base_set_hnp_name(void)
     /* set the nspace */
     PMIX_LOAD_NSPACE(prte_process_info.myproc.nspace, evar);
     prte_process_info.myproc.rank = 0;
-
 
     /* done */
     free(evar);
@@ -135,6 +139,8 @@ int prte_plm_base_create_jobid(prte_job_t *jdata)
     prte_asprintf(&tmp, "%s.%u", prte_process_info.myproc.nspace, (unsigned)prte_plm_globals.next_jobid);
     PMIX_LOAD_NSPACE(jdata->nspace, tmp);
     free(tmp);
+    // This routine will create a new prte_job_t structure and add it to the
+    // prte_job_data hash table at the ".N" position.
     PRTE_PMIX_CONVERT_NSPACE(rc, &jdata->jobid, jdata->nspace);
     if (PRTE_SUCCESS != rc) {
         return rc;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -302,8 +302,11 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
          * step required before we launch the daemons. It allows
          * the prte_rmaps_base_setup_virtual_machine routine to
          * search all apps for any hosts to be used by the vm
+         *
+         * Note that the prte_plm_base_create_jobid function will
+         * place the "caddy->jdata" object at the correct position
+         * in the hash table. There is no need to store it again here.
          */
-        prte_hash_table_set_value_uint32(prte_job_data, caddy->jdata->jobid, caddy->jdata);
     }
 
     /* if job recovery is not enabled, set it to default */

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -171,7 +172,8 @@ void prte_plm_base_recv(int status, prte_process_name_t* sender,
         if (PRTE_SUCCESS == rc) {
             job = jb.jobid;
         }
-        PRTE_DESTRUCT(&jb);
+        // The 'jb' object is now stored as reference in the prte_job_data hash
+        // by the prte_plm_base_create_jobid function.
 
         /* setup the response */
         answer = PRTE_NEW(prte_buffer_t);

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -970,7 +970,7 @@ void prte_state_base_check_all_complete(int fd, short args, void *cbdata)
                  * is maintained!
                  */
                 if (1 < j) {
-                    prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, NULL);
+                    prte_set_job_data_object(jdata->jobid, NULL);
                     PRTE_RELEASE(jdata);
                 }
             }

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -538,7 +538,7 @@ static void track_procs(int fd, short argc, void *cbdata)
             }
 
             /* cleanup the job info */
-            prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, NULL);
+            prte_set_job_data_object(jdata->jobid, NULL);
             PRTE_RELEASE(jdata);
         }
     }

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -8,6 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,7 +77,11 @@ void prte_convert_daemon_nspace(prte_jobid_t *jobid, pmix_nspace_t nspace)
     jobfam = (uint16_t)(((0x0000ffff & (0xffff0000 & hash32) >> 16)) ^ (0x0000ffff & hash32));
     jdata->jobid = (0xffff0000 & ((uint32_t)jobfam << 16));
     *jobid = jdata->jobid;
-    prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+
+    /*
+     * Add this temporary job object to the hash as a placeholder.
+     */
+    prte_set_job_data_object(jdata->jobid, jdata);
 }
 
 int prte_convert_nspace_to_jobid(prte_jobid_t *jobid, pmix_nspace_t nspace)
@@ -128,7 +133,11 @@ int prte_convert_nspace_to_jobid(prte_jobid_t *jobid, pmix_nspace_t nspace)
     jobfam = (uint16_t)(((0x0000ffff & (0xffff0000 & hash32) >> 16)) ^ (0x0000ffff & hash32));
     jdata->jobid = (0xffff0000 & ((uint32_t)jobfam << 16)) | (0x0000ffff & localjob);
     *jobid = jdata->jobid;
-    prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+
+    /*
+     * Add this temporary job object to the hash as a placeholder.
+     */
+    prte_set_job_data_object(jdata->jobid, jdata);
 
     return PRTE_SUCCESS;
 }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -745,7 +745,7 @@ void prte_pmix_server_tool_conn_complete(prte_job_t *jdata,
     /* flag that it is not to be monitored */
     PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_DO_NOT_MONITOR);
     /* store it away */
-    prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+    prte_set_job_data_object(jdata->jobid, jdata);
 
     /* must create a map for it (even though it has no
      * info in it) so that the job info will be picked

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -18,6 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -89,7 +90,7 @@ static void _query(int sd, short args, void *cbdata)
     bool local_only;
     prte_namelist_t *nm;
     prte_list_t targets;
-    int i, num_replies;
+    int i, num_replies, matched;
     pmix_proc_info_t *procinfo;
     pmix_info_t *info;
     pmix_data_array_t *darray;
@@ -123,7 +124,38 @@ static void _query(int sd, short args, void *cbdata)
         /* see if they provided any qualifiers */
         if (NULL != q->qualifiers && 0 < q->nqual) {
             for (n=0; n < q->nqual; n++) {
+                prte_output_verbose(2, prte_pmix_server_globals.output,
+                                    "%s qualifier key \"%s\" : value \"%s\"",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                    q->qualifiers[n].key,
+                                    (q->qualifiers[n].value.type == PMIX_STRING ? q->qualifiers[n].value.data.string : "(not a string)"));
                 if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_NSPACE)) {
+                    /* Never trust the namespace string that is provided.
+                     * First check to see if we know about this namespace. If
+                     * not then return an error. If so then continue on.
+                     * Note that the "PRTE_PMIX_CONVERT_NSPACE" function will create
+                     * a new prte_job_t structure an add it to the list.
+                     */
+                    /* Make sure the qualifier namespace exists */
+                    matched = 0;
+                    PRTE_HASH_TABLE_FOREACH(key, uint32, jdata, prte_job_data) {
+                        if (NULL != jdata &&
+                            PMIX_CHECK_NSPACE(q->qualifiers[n].value.data.string,
+                                              jdata->nspace)) {
+                            matched = 1;
+                            break;
+                        }
+                    }
+                    if (0 == matched) {
+                        prte_output_verbose(2, prte_pmix_server_globals.output,
+                                            "%s qualifier key \"%s\" : value \"%s\" is an unknown namespace",
+                                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                            q->qualifiers[n].key,
+                                            q->qualifiers[n].value.data.string);
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
+
                     PRTE_PMIX_CONVERT_NSPACE(rc, &jobid, q->qualifiers[n].value.data.string);
                     if (PRTE_JOBID_INVALID == jobid || PRTE_SUCCESS != rc) {
                         ret = PMIX_ERR_BAD_PARAM;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -422,6 +422,18 @@ PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_proc_t);
  * service
  */
 PRTE_EXPORT   prte_job_t* prte_get_job_data_object(prte_jobid_t job);
+
+/**
+ * Set a job data object
+ * This will return the 'old' object at the specified location.
+ * If there was none then NULL is returned.
+ */
+PRTE_EXPORT prte_job_t* prte_set_job_data_object(prte_jobid_t jobid, prte_job_t *jdata);
+
+/**
+ * Debug function that displays the job data hash table
+ */
+PRTE_EXPORT void prte_display_prte_job_data(const char * msg);
 
 /**
  * Get a proc data object


### PR DESCRIPTION
A few items all related to cause this error.
 * In finalize we destruct the `prte_job_data` in a loop. Since we cannot know the order in which job items will be popped off of the hash it is possible that this tries to finalize the child job before the parent job. In a debug build this causes an assert in `prte_list_item_destruct` since we are destructing a list item that is a member of another list - namely the `children` list of the parent.
   - To fix this we need to first clear the children list from all jobs, before we destroy the job structures.
 * If the tool calls `PMIx_Query_info` with the qualifier `PMIX_NSPACE` that contains an unknown namespace (or bogus namespace) then the query function will create a job structure for it and add it to the list. If the `PMIX_NSPACE` is of the form `prterun-c712f6n0132359.0` then it will replace the `prte`/`prterun` daemon's entry in the `prte_job_data` hash orphaning the prior object. The prior object is the one that has a `children` list containing the application that was launched.
   - To fix this we need to (1) check the validity of the namespace passed to this function and return an error. (2) Make sure we do not create a new job structure for this bogus namespace which can confuse or, worse, overwrite good job structures in the hash table.
 * The `prte_plm_base_create_jobid` function will ensure that the `prte_job_t` structure passed to it is the one that is stored in the `prte_job_data` hash table at the new `jobid` position. This tightens up a window of time where the temporary object in the hash table (from `prte_convert_nspace_to_jobid` since this is a new jobid) is in the hash table instead of the actual `jdata` object passed to `prte_plm_base_create_jobid`.
 * Add some helper functions for the `prte_job_data` structure
   - `prte_set_job_data_object`
   - `prte_display_prte_job_data` debugging helper
